### PR TITLE
fix: routing, revision ownership check, and updated_at consistency

### DIFF
--- a/server/routes/posts.ts
+++ b/server/routes/posts.ts
@@ -13,25 +13,25 @@ router.get("/", (_req, res) => {
   res.json(posts);
 });
 
+/** GET /api/posts/slug/:slug */
+router.get("/slug/:slug", (req, res) => {
+    const db = getDb();
+    const post = db
+        .prepare("SELECT * FROM posts WHERE slug = ?")
+        .get(req.params.slug);
+    if (!post) {
+        res.status(404).json({ error: "Post not found." });
+        return;
+    }
+    res.json(post);
+});
+
 /** GET /api/posts/:id */
 router.get("/:id", (req, res) => {
   const db = getDb();
   const post = db
     .prepare("SELECT * FROM posts WHERE id = ?")
     .get(req.params.id);
-  if (!post) {
-    res.status(404).json({ error: "Post not found." });
-    return;
-  }
-  res.json(post);
-});
-
-/** GET /api/posts/slug/:slug */
-router.get("/slug/:slug", (req, res) => {
-  const db = getDb();
-  const post = db
-    .prepare("SELECT * FROM posts WHERE slug = ?")
-    .get(req.params.slug);
   if (!post) {
     res.status(404).json({ error: "Post not found." });
     return;
@@ -99,6 +99,13 @@ router.patch("/:id", (req, res) => {
     values.push(title);
   }
   if (typeof published_revision_id === "string") {
+    const rev = db
+      .prepare("SELECT id FROM post_revisions WHERE id = ? AND post_id = ?")
+      .get(published_revision_id, req.params.id);
+    if (!rev) {
+      res.status(422).json({ error: "Revision does not belong to this post." });
+      return;
+    }
     fields.push("published_revision_id = ?", "published_at = ?");
     values.push(published_revision_id, now);
   }

--- a/server/routes/revisions.ts
+++ b/server/routes/revisions.ts
@@ -66,28 +66,41 @@ router.post("/", (req: Request<PostParams>, res: Response) => {
   }
 
   const lastRevision = db
-    .prepare(
-      "SELECT revision_number FROM post_revisions WHERE post_id = ? ORDER BY revision_number DESC LIMIT 1",
-    )
-    .get(req.params.postId) as { revision_number: number } | undefined;
+      .prepare(
+          "SELECT revision_number FROM post_revisions WHERE post_id = ? ORDER BY revision_number DESC LIMIT 1",
+      )
+      .get(req.params.postId) as { revision_number: number } | undefined;
 
   const revision_number = (lastRevision?.revision_number ?? 0) + 1;
   const id = randomUUID();
   const created_at = new Date().toISOString();
   const ir_json_str =
-    typeof ir_json === "string" ? ir_json : JSON.stringify(ir_json);
+      typeof ir_json === "string" ? ir_json : JSON.stringify(ir_json);
 
-  db.prepare(
-    "INSERT INTO post_revisions (id, post_id, revision_number, created_by, created_at, ir_schema_version, ir_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
-  ).run(
-    id,
-    req.params.postId,
-    revision_number,
-    created_by,
-    created_at,
-    IR_SCHEMA_VERSION,
-    ir_json_str,
+  const insert = db.prepare(
+      "INSERT INTO post_revisions (id, post_id, revision_number, created_by, created_at, ir_schema_version, ir_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
   );
+  const updatePost = db.prepare(
+      "UPDATE posts SET updated_at = ? WHERE id = ?",
+  );
+
+  db.exec("BEGIN");
+  try {
+    insert.run(
+        id,
+        req.params.postId,
+        revision_number,
+        created_by,
+        created_at,
+        IR_SCHEMA_VERSION,
+        ir_json_str,
+    );
+    updatePost.run(created_at, req.params.postId);
+    db.exec("COMMIT");
+  } catch (error) {
+    db.exec("ROLLBACK");
+    throw error;
+  }
 
   res.status(201).json({ id, revision_number });
 });


### PR DESCRIPTION
Fixes three issues identified during a review of the DB integration routes.

**Express route shadowing (`posts.ts`)**
`GET /slug/:slug` was registered after `GET /:id`, making it unreachable —
Express would match `slug` as the `:id` parameter first. Moved the slug route
above `/:id` to fix this.

**Revision ownership check (`posts.ts`)**
The PATCH handler accepted any `published_revision_id` without verifying it
belonged to the post being updated, allowing a dangling reference to be written.
Added a lookup against `post_revisions` before the update, returning 422 if the
revision doesn't belong to the post.

**Transaction for revision creation (`revisions.ts`)**
Creating a new revision updated `post_revisions` but left `posts.updated_at`
unchanged, meaning the post's last-modified timestamp would fall out of sync with
its revision history. Wrapped both writes in a transaction so they succeed or fail
together.