### PR TITLE
posts and revisions now use the logged-in session user instead of cli…

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -33,5 +33,15 @@ export function createApp() {
   app.use("/api/posts", postsRouter);
   app.use("/api/posts/:postId/revisions", revisionsRouter);
 
+  // JSON error handler — convert thrown errors to clean JSON responses
+  // (err, req, res, next) signature is required by Express to mark it as error handler
+  app.use((err: unknown, _req: import("express").Request, res: import("express").Response, next: import("express").NextFunction) => {
+    // eslint-disable-next-line no-console
+    console.error(err);
+    if (res.headersSent) return next(err as Error);
+    const message = err instanceof Error ? err.message : String(err);
+    res.status(500).json({ error: message });
+  });
+
   return app;
 }

--- a/server/routes/posts.ts
+++ b/server/routes/posts.ts
@@ -41,31 +41,43 @@ router.get("/:id", (req, res) => {
 
 /** POST /api/posts - create a post */
 router.post("/", (req, res) => {
-  const { slug, title, created_by } = req.body as {
+  const { slug, title } = req.body as {
     slug?: unknown;
     title?: unknown;
-    created_by?: unknown;
   };
 
-  if (
-    typeof slug !== "string" ||
-    typeof title !== "string" ||
-    typeof created_by !== "string"
-  ) {
-    res.status(400).json({
-      error: "'slug', 'title', and 'created_by' string fields are required.",
-    });
+  const email = req.session.userEmail;
+  if (!email) {
+    res.status(401).json({ error: "Not logged in." });
+    return;
+  }
+
+  if (typeof slug !== "string" || typeof title !== "string") {
+    res.status(400).json({ error: "'slug' and 'title' string fields are required." });
     return;
   }
 
   const db = getDb();
+  // Check for existing slug to give a clear 409 conflict response
+  const existing = db.prepare("SELECT id FROM posts WHERE slug = ?").get(slug);
+  if (existing) {
+    res.status(409).json({ error: "Post slug already exists." });
+    return;
+  }
   const id = randomUUID();
   const now = new Date().toISOString();
 
+  const user = db.prepare("SELECT id FROM users WHERE email = ?").get(email) as
+    | { id: string }
+    | undefined;
+  if (!user) {
+    res.status(401).json({ error: "Not logged in." });
+    return;
+  }
+
   db.prepare(
     "INSERT INTO posts (id, slug, title, created_by, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
-  ).run(id, slug, title, created_by, now, now);
-
+  ).run(id, slug, title, user.id, now, now);
   res.status(201).json({ id });
 });
 

--- a/server/routes/revisions.ts
+++ b/server/routes/revisions.ts
@@ -15,7 +15,7 @@ router.get("/", (req: Request<PostParams>, res: Response) => {
   const db = getDb();
   const revisions = db
     .prepare(
-      "SELECT id, post_id, revision_number, created_by, created_at, ir_schema_version FROM post_revisions WHERE post_id = ? ORDER BY revision_number ASC",
+      "SELECT id, post_id, revision_number, created_by, created_at, ir_schema_version, ir_json FROM post_revisions WHERE post_id = ? ORDER BY revision_number DESC",
     )
     .all(req.params.postId);
   res.json(revisions);
@@ -36,15 +36,16 @@ router.get("/:revisionId", (req: Request<RevisionParams>, res: Response) => {
 
 /** POST /api/posts/:postId/revisions - create a new revision */
 router.post("/", (req: Request<PostParams>, res: Response) => {
-  const { created_by, ir_json } = req.body as {
-    created_by?: unknown;
+  const { ir_json } = req.body as {
     ir_json?: unknown;
   };
 
-  if (typeof created_by !== "string") {
-    res.status(400).json({ error: "'created_by' string field is required." });
+  const email = req.session.userEmail;
+  if (!email) {
+    res.status(401).json({ error: "Not logged in." });
     return;
   }
+
   if (
     typeof ir_json !== "string" &&
     (typeof ir_json !== "object" || ir_json === null)
@@ -77,6 +78,14 @@ router.post("/", (req: Request<PostParams>, res: Response) => {
   const ir_json_str =
       typeof ir_json === "string" ? ir_json : JSON.stringify(ir_json);
 
+  const user = db.prepare("SELECT id FROM users WHERE email = ?").get(email) as
+    | { id: string }
+    | undefined;
+  if (!user) {
+    res.status(401).json({ error: "Not logged in." });
+    return;
+  }
+
   const insert = db.prepare(
       "INSERT INTO post_revisions (id, post_id, revision_number, created_by, created_at, ir_schema_version, ir_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
   );
@@ -87,13 +96,13 @@ router.post("/", (req: Request<PostParams>, res: Response) => {
   db.exec("BEGIN");
   try {
     insert.run(
-        id,
-        req.params.postId,
-        revision_number,
-        created_by,
-        created_at,
-        IR_SCHEMA_VERSION,
-        ir_json_str,
+      id,
+      req.params.postId,
+      revision_number,
+      user.id,
+      created_at,
+      IR_SCHEMA_VERSION,
+      ir_json_str,
     );
     updatePost.run(created_at, req.params.postId);
     db.exec("COMMIT");

--- a/src/api.ts
+++ b/src/api.ts
@@ -19,6 +19,7 @@ async function req<T>(
     const text = await res.text().catch(() => res.statusText)
     throw new Error(text || `HTTP ${res.status}`)
   }
+  if (res.status === 204) return Promise.resolve(undefined as unknown as T)
   return res.json() as Promise<T>
 }
 
@@ -52,8 +53,8 @@ export interface Post {
 
 export const posts = {
   list: ()                            => req<Post[]>('GET', '/posts'),
-  create: (slug: string, title: string, created_by: string) =>
-    req<Post>('POST', '/posts', { slug, title, created_by }),
+  create: (slug: string, title: string) =>
+    req<Post>('POST', '/posts', { slug, title }),
   update: (id: string, patch: Partial<Pick<Post, 'slug' | 'title' | 'published_revision_id'>>) =>
     req<Post>('PATCH', `/posts/${id}`, patch),
   delete: (id: string)                => req<void>('DELETE', `/posts/${id}`),
@@ -84,7 +85,7 @@ export const parse = (markdown: string) =>
   req<{ nodes: unknown[] }>('POST', '/parse', { markdown })
 
 export const renderIR = (irJson: unknown) =>
-  req<{ html: string }>('POST', '/render/ir', { ir_json: JSON.stringify(irJson) })
+  req<{ html: string }>('POST', '/render/ir', { nodes: irJson })
 
 export const renderMarkdown = (markdown: string) =>
   req<{ html: string }>('POST', '/render/markdown', { markdown })

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -13,6 +13,7 @@
 import React, { useState, useCallback, useRef } from 'react'
 import DOMPurify from 'dompurify'
 import { parse, renderIR, posts, revisions, Post, Revision } from '../api'
+import { markdownRenderer } from '../ir/markdown_renderer'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -161,7 +162,7 @@ export default function Editor({ userId, userEmail, onLogout }: Props) {
       let post = activePost
       if (!post) {
         setStatus({ kind: 'working', message: 'Creating post record…' })
-        post = await posts.create(slugify(title), title.trim(), userId)
+        post = await posts.create(slugify(title), title.trim())
         setActivePost(post)
       } else if (post.title !== title.trim()) {
         post = await posts.update(post.id, { title: title.trim() })
@@ -223,13 +224,9 @@ export default function Editor({ userId, userEmail, onLogout }: Props) {
       setPreviewHtml(html)
       setActivePost(post)
       setTitle(post.title)
-      // We don't try to reconstruct Markdown from IR here — that's IR→MD (week 9).
-      // Instead show a note in the editor.
-      setMarkdown(
-        `<!-- Post loaded from IR. Markdown reconstruction is not yet implemented.\n` +
-        `     Edit here to create a new revision. -->\n\n` +
-        `# ${post.title}\n`
-      )
+      // Reconstruct Markdown from IR
+      const reconstructed = markdownRenderer.renderDocument({ kind: 'Document', nodes: ir })
+      setMarkdown(reconstructed)
       setView('editor')
       setStatus({ kind: 'ok', message: `Loaded "${post.title}" · revision ${latest.id.slice(0, 8)}` })
     } catch (err: unknown) {

--- a/src/ir/markdown_parser.ts
+++ b/src/ir/markdown_parser.ts
@@ -1,6 +1,7 @@
 import type {
   BulletBlock,
   BulletItemNode,
+  CodeBlockNode,
   HeaderNode,
   ImageSpan,
   ImageNode,
@@ -25,6 +26,13 @@ export function parseMarkdownToIR(markdown: string): Result<IRNode[], Error> {
       if (imageNode) {
         nodes.push(imageNode);
         i++;
+        continue;
+      }
+
+      if (isFencedCodeBlockStart(lines[i])) {
+        const codeBlock = getCodeBlock(lines, i);
+        nodes.push(codeBlock.codeblock);
+        i = codeBlock.endIndex;
         continue;
       }
 
@@ -132,6 +140,46 @@ function isHeader(line: string): boolean {
   return /^(#{1,6})\s*(.*)$/.test(line);
 }
 
+function isFencedCodeBlockStart(line: string): boolean {
+  return /^```/.test(line.trim());
+}
+
+function parseFencedCodeBlockStart(
+  line: string,
+): { language?: string } | null {
+  const match = line.trim().match(/^```\s*([^`]*)\s*$/);
+  if (!match) return null;
+
+  const language = match[1].trim();
+  return language.length > 0 ? { language } : {};
+}
+
+function getCodeBlock(
+  lines: string[],
+  start: number,
+): { codeblock: CodeBlockNode; endIndex: number } {
+  const startInfo = parseFencedCodeBlockStart(lines[start]);
+  const content: string[] = [];
+  let i = start + 1;
+
+  while (i < lines.length && lines[i].trim() !== "```") {
+    content.push(lines[i]);
+    i++;
+  }
+
+  if (i < lines.length && lines[i].trim() === "```") {
+    i++;
+  }
+
+  const codeblock: CodeBlockNode = {
+    kind: "CodeBlock",
+    content,
+    ...startInfo,
+  };
+
+  return { codeblock, endIndex: i };
+}
+
 function getBulletBlock(
   lines: string[],
   start: number,
@@ -182,9 +230,20 @@ function parseInlineSpans(text: string): Line {
   while (index < text.length) {
     const wikiStart = text.indexOf("![[", index);
     const markdownStart = text.indexOf("![", index);
+    const strongStart = text.indexOf("**", index);
+    const emphasisStart = text.indexOf("*", index);
+    const codeStart = text.indexOf("`", index);
+    const linkStart = text.indexOf("[", index);
 
     let start = -1;
-    let syntax: "wiki" | "markdown" | null = null;
+    let syntax:
+      | "wiki"
+      | "markdown"
+      | "strong"
+      | "emphasis"
+      | "code"
+      | "link"
+      | null = null;
 
     if (wikiStart !== -1 && (markdownStart === -1 || wikiStart <= markdownStart)) {
       start = wikiStart;
@@ -192,6 +251,26 @@ function parseInlineSpans(text: string): Line {
     } else if (markdownStart !== -1) {
       start = markdownStart;
       syntax = "markdown";
+    }
+
+    if (strongStart !== -1 && (start === -1 || strongStart < start)) {
+      start = strongStart;
+      syntax = "strong";
+    }
+
+    if (emphasisStart !== -1 && (start === -1 || emphasisStart < start)) {
+      start = emphasisStart;
+      syntax = "emphasis";
+    }
+
+    if (codeStart !== -1 && (start === -1 || codeStart < start)) {
+      start = codeStart;
+      syntax = "code";
+    }
+
+    if (linkStart !== -1 && (start === -1 || linkStart < start)) {
+      start = linkStart;
+      syntax = "link";
     }
 
     if (start === -1) {
@@ -214,6 +293,72 @@ function parseInlineSpans(text: string): Line {
       const [href, alt] = raw.split("|", 2);
       spans.push(buildImageSpan(href, alt));
       index = end + 2;
+      continue;
+    }
+
+    if (syntax === "strong") {
+      const end = text.indexOf("**", start + 2);
+      if (end === -1) {
+        spans.push(text.slice(start, start + 2));
+        index = start + 2;
+        continue;
+      }
+
+      spans.push({
+        kind: "Strong",
+        content: parseInlineSpans(text.slice(start + 2, end)),
+      });
+      index = end + 2;
+      continue;
+    }
+
+    if (syntax === "emphasis") {
+      const end = text.indexOf("*", start + 1);
+      if (end === -1) {
+        spans.push(text.slice(start, start + 1));
+        index = start + 1;
+        continue;
+      }
+
+      spans.push({
+        kind: "Emphasis",
+        content: parseInlineSpans(text.slice(start + 1, end)),
+      });
+      index = end + 1;
+      continue;
+    }
+
+    if (syntax === "code") {
+      const end = text.indexOf("`", start + 1);
+      if (end === -1) {
+        spans.push(text.slice(start, start + 1));
+        index = start + 1;
+        continue;
+      }
+
+      spans.push({
+        kind: "Code",
+        code: text.slice(start + 1, end),
+      });
+      index = end + 1;
+      continue;
+    }
+
+    if (syntax === "link") {
+      const altEnd = text.indexOf("](", start + 1);
+      const hrefEnd = altEnd === -1 ? -1 : text.indexOf(")", altEnd + 2);
+      if (altEnd === -1 || hrefEnd === -1) {
+        spans.push(text.slice(start, start + 1));
+        index = start + 1;
+        continue;
+      }
+
+      spans.push({
+        kind: "Link",
+        href: text.slice(altEnd + 2, hrefEnd),
+        content: parseInlineSpans(text.slice(start + 1, altEnd)),
+      });
+      index = hrefEnd + 1;
       continue;
     }
 

--- a/tests/ir/markdown_parser.test.ts
+++ b/tests/ir/markdown_parser.test.ts
@@ -1,3 +1,44 @@
+import { markdownRenderer } from "../../src/ir/markdown_renderer"
+
+describe("End-to-end: save/load/resave cycle", () => {
+  it("should preserve mixed markers through a full save/load/resave cycle", () => {
+    const originalMarkdown = `# My List
+
+- First item
+* Second item
+- Third item`;
+
+    // Step 1: Parse original markdown
+    const parseResult = parseMarkdownToIR(originalMarkdown);
+    expect(parseResult.isOk()).toBe(true);
+    if (!parseResult.isOk()) return;
+
+    const ir = parseResult.value;
+
+    // Step 2: Simulate saving to DB (JSON stringify)
+    const jsonStr = JSON.stringify(ir);
+    const irFromJson = JSON.parse(jsonStr);
+
+    // Step 3: Reconstruct markdown from IR
+    const reconstructed = markdownRenderer.renderDocument({ kind: 'Document', nodes: irFromJson });
+
+    // Step 4: Parse the reconstructed markdown again
+    const reparsedResult = parseMarkdownToIR(reconstructed);
+    expect(reparsedResult.isOk()).toBe(true);
+    if (!reparsedResult.isOk()) return;
+
+    const reparsedIr = reparsedResult.value;
+
+    // Step 5: Verify markers are preserved through the cycle
+    const bulletBlock = reparsedIr[1] as any; // Index 1 should be the bullet list (after header)
+    expect(bulletBlock.kind).toBe("BulletedList");
+    expect(bulletBlock.content).toHaveLength(3);
+
+    expect(bulletBlock.content[0].markerByLanguage).toEqual({ markdown: "-" });
+    expect(bulletBlock.content[1].markerByLanguage).toEqual({ markdown: "*" });
+    expect(bulletBlock.content[2].markerByLanguage).toEqual({ markdown: "-" });
+  });
+});
 import { describe, it, expect } from "vitest";
 import { parseMarkdownToIR } from "../../src/ir/markdown_parser";
 import type {
@@ -5,6 +46,7 @@ import type {
   ParagraphNode,
   BulletBlock,
   NumberedBlock,
+  CodeBlockNode,
 } from "../../src/ir/types";
 
 describe("parseMarkdownToIR", () => {
@@ -122,6 +164,34 @@ This is line three.`;
       }
     });
 
+    it("should parse bold, italic, code, and links inside a paragraph", () => {
+      const markdown = "This is **bold**, *italic*, `code`, and [a link](https://example.com).";
+      const result = parseMarkdownToIR(markdown);
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const paragraph = result.value[0] as ParagraphNode;
+        expect(paragraph.kind).toBe("Paragraph");
+        expect(paragraph.content).toEqual([
+          [
+            "This is ",
+            { kind: "Strong", content: ["bold"] },
+            ", ",
+            { kind: "Emphasis", content: ["italic"] },
+            ", ",
+            { kind: "Code", code: "code" },
+            ", and ",
+            {
+              kind: "Link",
+              href: "https://example.com",
+              content: ["a link"],
+            },
+            ".",
+          ],
+        ]);
+      }
+    });
+
     it("should separate paragraphs by blank lines", () => {
       const markdown = `First paragraph.
 
@@ -189,6 +259,40 @@ Second paragraph.`;
         if (item2.kind === "BulletItem") {
           expect(item2.content).toEqual([["Second item"]]);
           expect(item2.markerByLanguage).toEqual({ markdown: "*" });
+        }
+      }
+    });
+
+    it("should parse a bulleted list with mixed markers (* and -)", () => {
+      const markdown = `- First item
+* Second item
+- Third item`;
+
+      const result = parseMarkdownToIR(markdown);
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toHaveLength(1);
+        const bulletBlock = result.value[0] as BulletBlock;
+        expect(bulletBlock.kind).toBe("BulletedList");
+        expect(bulletBlock.content).toHaveLength(3);
+
+        const item1 = bulletBlock.content[0];
+        if (item1.kind === "BulletItem") {
+          expect(item1.content).toEqual([["First item"]]);
+          expect(item1.markerByLanguage).toEqual({ markdown: "-" });
+        }
+
+        const item2 = bulletBlock.content[1];
+        if (item2.kind === "BulletItem") {
+          expect(item2.content).toEqual([["Second item"]]);
+          expect(item2.markerByLanguage).toEqual({ markdown: "*" });
+        }
+
+        const item3 = bulletBlock.content[2];
+        if (item3.kind === "BulletItem") {
+          expect(item3.content).toEqual([["Third item"]]);
+          expect(item3.markerByLanguage).toEqual({ markdown: "-" });
         }
       }
     });
@@ -293,6 +397,47 @@ Second paragraph.`;
     });
   });
 
+  describe("Code Blocks", () => {
+    it("should parse a fenced code block without a language", () => {
+      const markdown = [
+        "```",
+        "const value = 1;",
+        "console.log(value);",
+        "```",
+      ].join("\n");
+
+      const result = parseMarkdownToIR(markdown);
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toHaveLength(1);
+        const codeBlock = result.value[0] as CodeBlockNode;
+        expect(codeBlock.kind).toBe("CodeBlock");
+        expect(codeBlock.language).toBeUndefined();
+        expect(codeBlock.content).toEqual(["const value = 1;", "console.log(value);"]);
+      }
+    });
+
+    it("should parse a fenced code block with a language", () => {
+      const markdown = [
+        "```ts",
+        "const value: number = 1;",
+        "```",
+      ].join("\n");
+
+      const result = parseMarkdownToIR(markdown);
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toHaveLength(1);
+        const codeBlock = result.value[0] as CodeBlockNode;
+        expect(codeBlock.kind).toBe("CodeBlock");
+        expect(codeBlock.language).toBe("ts");
+        expect(codeBlock.content).toEqual(["const value: number = 1;"]);
+      }
+    });
+  });
+
   describe("Mixed Content", () => {
     it("should parse a document with headers and paragraphs", () => {
       const markdown = `# Title
@@ -348,6 +493,39 @@ Final paragraph.`;
         expect(kinds).toContain("Paragraph");
         expect(kinds).toContain("BulletedList");
         expect(kinds).toContain("NumberedList");
+      }
+    });
+
+    it("should parse a document with a fenced code block", () => {
+      const markdown = [
+        "# Title",
+        "",
+        "Intro paragraph.",
+        "",
+        "```js",
+        "const answer = 42;",
+        "console.log(answer);",
+        "```",
+        "",
+        "Final paragraph.",
+      ].join("\n");
+
+      const result = parseMarkdownToIR(markdown);
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toHaveLength(4);
+        expect(result.value[0].kind).toBe("Header");
+        expect(result.value[1].kind).toBe("Paragraph");
+        expect(result.value[2].kind).toBe("CodeBlock");
+        expect(result.value[3].kind).toBe("Paragraph");
+
+        const codeBlock = result.value[2] as CodeBlockNode;
+        expect(codeBlock.language).toBe("js");
+        expect(codeBlock.content).toEqual([
+          "const answer = 42;",
+          "console.log(answer);",
+        ]);
       }
     });
 

--- a/tests/ir/markdown_renderer.test.ts
+++ b/tests/ir/markdown_renderer.test.ts
@@ -332,6 +332,32 @@ describe("markdownRenderer", () => {
       expect(markdownRenderer.renderListBlock(list)).toBe("- Item");
     });
 
+    it("preserves mixed bullet markers (* and -)", () => {
+      const list: BulletBlock = {
+        kind: "BulletedList",
+        content: [
+          {
+            kind: "BulletItem",
+            content: [["First item"]],
+            markerByLanguage: { markdown: "-" },
+          },
+          {
+            kind: "BulletItem",
+            content: [["Second item"]],
+            markerByLanguage: { markdown: "*" },
+          },
+          {
+            kind: "BulletItem",
+            content: [["Third item"]],
+            markerByLanguage: { markdown: "-" },
+          },
+        ],
+      };
+      expect(markdownRenderer.renderListBlock(list)).toBe(
+        "- First item\n* Second item\n- Third item",
+      );
+    });
+
     it("renders a simple numbered list", () => {
       const list: NumberedBlock = {
         kind: "NumberedList",

--- a/tests/server/posts.test.ts
+++ b/tests/server/posts.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { setupTestServer } from "./helpers.ts";
 
-const { get, post, patch, del } = setupTestServer();
+const { get, post, patch, del, cookieFrom } = setupTestServer();
 
 // ---------------------------------------------------------------------------
 // Users
@@ -50,24 +50,27 @@ describe("DELETE /api/users/:id", () => {
 // Posts — requires a user in the DB first
 // ---------------------------------------------------------------------------
 
-let userId: string;
 let postId: string;
+let authCookie: string;
 
 beforeAll(async () => {
-  const res = await post("/api/users", {
-    hanko_user_id: "hanko-posts",
+  const res = await post("/api/auth/signup", {
     email: "posts@example.com",
+    password: "password",
   });
-  ({ id: userId } = (await res.json()) as { id: string });
+  authCookie = cookieFrom(res);
 });
 
 describe("POST /api/posts", () => {
   it("creates a post and returns its id", async () => {
-    const res = await post("/api/posts", {
-      slug: "first-post",
-      title: "First Post",
-      created_by: userId,
-    });
+    const res = await post(
+      "/api/posts",
+      {
+        slug: "first-post",
+        title: "First Post",
+      },
+      { headers: { "Content-Type": "application/json", Cookie: authCookie } },
+    );
     expect(res.status).toBe(201);
     const body = (await res.json()) as { id: string };
     postId = body.id;
@@ -76,7 +79,7 @@ describe("POST /api/posts", () => {
 
   it("returns 400 when required fields are missing", async () => {
     const res = await post("/api/posts", { title: "No slug or author" });
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(401);
   });
 });
 
@@ -126,12 +129,15 @@ let revisionId: string;
 
 describe("POST /api/posts/:postId/revisions", () => {
   it("creates a revision and returns id + revision_number", async () => {
-    const res = await post(`/api/posts/${postId}/revisions`, {
-      created_by: userId,
-      ir_json: JSON.stringify([
-        { kind: "Header", level: 1, content: ["Hello"] },
-      ]),
-    });
+    const res = await post(
+      `/api/posts/${postId}/revisions`,
+      {
+        ir_json: JSON.stringify([
+          { kind: "Header", level: 1, content: ["Hello"] },
+        ]),
+      },
+      { headers: { "Content-Type": "application/json", Cookie: authCookie } },
+    );
     expect(res.status).toBe(201);
     const body = (await res.json()) as { id: string; revision_number: number };
     revisionId = body.id;
@@ -139,25 +145,27 @@ describe("POST /api/posts/:postId/revisions", () => {
   });
 
   it("auto-increments revision_number", async () => {
-    const res = await post(`/api/posts/${postId}/revisions`, {
-      created_by: userId,
-      ir_json: "{}",
-    });
+    const res = await post(
+      `/api/posts/${postId}/revisions`,
+      { ir_json: "{}" },
+      { headers: { "Content-Type": "application/json", Cookie: authCookie } },
+    );
     const body = (await res.json()) as { revision_number: number };
     expect(body.revision_number).toBe(2);
   });
 
   it("returns 404 when the post does not exist", async () => {
-    const res = await post("/api/posts/no-such-post/revisions", {
-      created_by: userId,
-      ir_json: "{}",
-    });
+    const res = await post(
+      "/api/posts/no-such-post/revisions",
+      { ir_json: "{}" },
+      { headers: { "Content-Type": "application/json", Cookie: authCookie } },
+    );
     expect(res.status).toBe(404);
   });
 
-  it("returns 400 when created_by is missing", async () => {
+  it("returns 401 when not logged in", async () => {
     const res = await post(`/api/posts/${postId}/revisions`, { ir_json: "{}" });
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(401);
   });
 });
 

--- a/tests/server/smoke.test.ts
+++ b/tests/server/smoke.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { setupTestServer } from "./helpers";
+
+const { get, post, cookieFrom } = setupTestServer();
+
+describe("smoke: user login and create post", () => {
+  let authCookie: string;
+  let postId: string;
+
+  beforeAll(async () => {
+    const res = await post("/api/auth/signup", { email: "smoke@example.com", password: "password" });
+    expect(res.status).toBe(201);
+    authCookie = cookieFrom(res);
+  });
+
+  it("creates a post when logged in", async () => {
+    const createRes = await post(
+      "/api/posts",
+      { slug: "smoke-post", title: "Smoke Post" },
+      { headers: { "Content-Type": "application/json", Cookie: authCookie } },
+    );
+    if (createRes.status !== 201) {
+      const text = await createRes.text().catch(() => "<no body>");
+      throw new Error(`Unexpected response ${createRes.status}: ${text}`);
+    }
+    const body = await createRes.json() as { id: string };
+    postId = body.id;
+
+    const getRes = await get(`/api/posts/${postId}`);
+    expect(getRes.status).toBe(200);
+    const postBody = await getRes.json() as { slug: string; title: string };
+    expect(postBody.slug).toBe("smoke-post");
+    expect(postBody.title).toBe("Smoke Post");
+
+    // --- Simulate saving: parse some markdown and create a revision ---
+    const parseRes = await post(
+      "/api/parse",
+      { markdown: "# Smoke Save\n\nHello world" },
+      { headers: { "Content-Type": "application/json", Cookie: authCookie } },
+    );
+    expect(parseRes.status).toBe(200);
+    const parseBody = await parseRes.json() as { nodes: unknown[] };
+    expect(Array.isArray(parseBody.nodes)).toBe(true);
+
+    const revRes = await post(
+      `/api/posts/${postId}/revisions`,
+      { ir_json: JSON.stringify(parseBody.nodes) },
+      { headers: { "Content-Type": "application/json", Cookie: authCookie } },
+    );
+    expect(revRes.status).toBe(201);
+    const revBody = await revRes.json() as { id: string; revision_number: number };
+    expect(typeof revBody.id).toBe("string");
+    expect(revBody.revision_number).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
…ent-supplied author data

duplicate post slugs now return a clean 409 instead of a sqlite error loading a post now pulls the newest revision correctly deletes now update the ui properly, and api 204 responses are handled safely the app now returns json errors instead of html stack traces markdown load now reconstructs from ir instead of showing the placeholder comment added fenced code block parsing
added inline parsing for **bold**, *italic*, inline code, and links mixed bullet markers are preserved correctly